### PR TITLE
oxipng precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/oxipng/oxipng
+    rev: v10.1.1
+    hooks:
+      - id: oxipng
+        args: ["--opt", "max", "--strip", "safe", "--alpha"]
+        files: ^assets/.*\.png$


### PR DESCRIPTION
Automatically losslessly compressed commited images with oxipng. Much simpler than the bash script I had before. I'm seeing about a 108MB reduction in files sizes with this.

You will need to install precommit and run `pre-commit install` once. After that you can run `pre-commit run -a` to compress all the existing images.